### PR TITLE
fix: prevent extra indentation from brackets on same line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgsl_analyzer"
+version = "0.1.0"
+dependencies = [
+ "zed_extension_api",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,11 +326,4 @@ dependencies = [
  "serde",
  "serde_json",
  "wit-bindgen",
-]
-
-[[package]]
-name = "zed_wgsl_analyzer"
-version = "0.1.0"
-dependencies = [
- "zed_extension_api",
 ]

--- a/extension.toml
+++ b/extension.toml
@@ -3,6 +3,7 @@ name = "WGSL"
 version = "0.0.1"
 schema_version = 1
 authors = ["Angus Morrison <angus@howtocodeit.com>"]
+repository = "https://github.com/AngusGMorrison/wgsl-analyzer"
 description = """
 WGSL language support with rich syntax highlighting. Powered by the
 wgsl-analyzer language server. See the README for configuration.

--- a/languages/wgsl/indents.scm
+++ b/languages/wgsl/indents.scm
@@ -1,4 +1,3 @@
-(_ "[" "]" @end) @indent
-(_ "{" "}" @end) @indent
-(_ "(" ")" @end) @indent
-("(" ")" @end) @indent
+("[" @start "]" @end) @indent
+("{" @start "}" @end) @indent
+("(" @start ")" @end) @indent


### PR DESCRIPTION
Prevents an extra level of indentation resulting from sets of brackets appearing on a single line.